### PR TITLE
Fix error while while starting database.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
         image: postgres:9
         ports:
           - 5432:5432
+        environment:
+          - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
I has an error while running `docker-compose up`:

```
postgres_1  | Error: Database is uninitialized and superuser password is not specified.
postgres_1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgres_1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgres_1  | 
postgres_1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgres_1  |        connections without a password. This is *not* recommended.
postgres_1  | 
postgres_1  |        See PostgreSQL documentation about "trust":
postgres_1  |        https://www.postgresql.org/docs/current/auth-trust.html

```

Problem solved by adding environment variable to docker-compose.yml file