### PR TITLE
Could com.github.simplesteph.kafka.streams:udemy-reviews-fraud:1.0-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/udemy-reviews-fraud/pom.xml
+++ b/udemy-reviews-fraud/pom.xml
@@ -35,6 +35,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
             <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -56,11 +62,6 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro-maven-plugin</artifactId>
             <version>${avro.version}</version>
         </dependency>
 
@@ -96,6 +97,12 @@
             <groupId>com.github.simplesteph.kafka.producer</groupId>
             <artifactId>udemy-reviews-producer</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-maven-plugin</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
@simplesteph Hi, I am a user of project **_com.github.simplesteph.kafka.streams:udemy-reviews-fraud:1.0-SNAPSHOT_**. I found that its pom file introduced **_67_** dependencies. However, among them, **_23_** libraries (**_34%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_com.github.simplesteph.kafka.streams:udemy-reviews-fraud:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards